### PR TITLE
Add market history service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ subprojects {
             dependency("io.github.oshai:kotlin-logging-jvm:7.0.13")
             dependency("net.javacrumbs.shedlock:shedlock-spring:6.10.0")
             dependency("net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.10.0")
+            dependency("com.influxdb:influxdb-client-java:7.3.0")
         }
 
         dependencies {

--- a/docker-compose/add-connector.sh
+++ b/docker-compose/add-connector.sh
@@ -70,3 +70,11 @@ docker exec -it mansour-kafka kafka-console-consumer \
   --from-beginning \
   --property print.key=true \
   --property key.separator=" : "
+
+
+docker exec -it mansour-kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 \
+  --topic marketdata.candles.1m \
+  --from-beginning \
+  --property print.key=true \
+  --property key.separator=" : "

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - DOCKER_INFLUXDB_INIT_USERNAME=admin
       - DOCKER_INFLUXDB_INIT_PASSWORD=adminpassword
       - DOCKER_INFLUXDB_INIT_ORG=mansour
-      - DOCKER_INFLUXDB_INIT_BUCKET=market_data
+      - DOCKER_INFLUXDB_INIT_BUCKET=market_history_data
       - DOCKER_INFLUXDB_INIT_RETENTION=30d
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token
       - TZ=Asia/Seoul

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -85,3 +85,21 @@ services:
       - ./redis-data:/data
     environment:
       - TZ=Asia/Seoul
+
+  influxdb:
+    image: influxdb:2.7
+    container_name: mansour-influxdb
+    ports:
+      - "18086:8086"
+    volumes:
+      - ./influxdb-data:/var/lib/influxdb2
+      - ./influxdb-config:/etc/influxdb2
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=adminpassword
+      - DOCKER_INFLUXDB_INIT_ORG=mansour
+      - DOCKER_INFLUXDB_INIT_BUCKET=market_data
+      - DOCKER_INFLUXDB_INIT_RETENTION=30d
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token
+      - TZ=Asia/Seoul

--- a/mansour/contracts/market-data-service-contract/src/main/kotlin/org/mj/mansour/contract/marketdata/StockPriceUpdatedEvent.kt
+++ b/mansour/contracts/market-data-service-contract/src/main/kotlin/org/mj/mansour/contract/marketdata/StockPriceUpdatedEvent.kt
@@ -15,6 +15,7 @@ object StockPriceUpdatedEvent {
         val high: BigDecimal,
         val low: BigDecimal,
         val close: BigDecimal,
-        val volume: BigDecimal
+        val volume: BigDecimal, // 누적 거래량
+        val tradeVolume: BigDecimal = BigDecimal.ZERO, // 체결 거래량
     )
 }

--- a/mansour/contracts/market-data-service-contract/src/main/kotlin/org/mj/mansour/contract/marketdata/StockPriceUpdatedEvent.kt
+++ b/mansour/contracts/market-data-service-contract/src/main/kotlin/org/mj/mansour/contract/marketdata/StockPriceUpdatedEvent.kt
@@ -16,6 +16,6 @@ object StockPriceUpdatedEvent {
         val low: BigDecimal,
         val close: BigDecimal,
         val volume: BigDecimal, // 누적 거래량
-        val tradeVolume: BigDecimal = BigDecimal.ZERO, // 체결 거래량
+        val tradeVolume: Long, // 체결 거래량
     )
 }

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/consumer/InterestAssetAddedEventHandler.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/consumer/InterestAssetAddedEventHandler.kt
@@ -1,4 +1,4 @@
-package org.mj.mansour.marketdata.event
+package org.mj.mansour.marketdata.event.consumer
 
 import org.mj.mansour.contract.activity.InterestAssetAddedEvent
 import org.mj.mansour.contract.asset.StockResponse

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/consumer/InterestAssetRemovedEventHandler.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/consumer/InterestAssetRemovedEventHandler.kt
@@ -1,4 +1,4 @@
-package org.mj.mansour.marketdata.event
+package org.mj.mansour.marketdata.event.consumer
 
 import org.mj.mansour.contract.activity.InterestAssetRemovedEvent
 import org.mj.mansour.contract.asset.StockResponse

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/internal/RawTickDataReceivedEvent.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/internal/RawTickDataReceivedEvent.kt
@@ -1,4 +1,4 @@
-package org.mj.mansour.marketdata.event
+package org.mj.mansour.marketdata.event.internal
 
 import org.mj.mansour.marketdata.kis.dto.KisRealtimePriceData
 

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/internal/RawTickDataReceivedEventHandler.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/internal/RawTickDataReceivedEventHandler.kt
@@ -1,4 +1,4 @@
-package org.mj.mansour.marketdata.event
+package org.mj.mansour.marketdata.event.internal
 
 import org.mj.mansour.contract.marketdata.StockPriceUpdatedEvent
 import org.mj.mansour.marketdata.service.OutboxService
@@ -38,7 +38,8 @@ class RawTickDataReceivedEventHandler(
             high = rawData.highestPrice,
             low = rawData.lowestPrice,
             close = rawData.currentPrice,
-            volume = rawData.accumulatedVolume
+            volume = rawData.accumulatedVolume,
+            tradeVolume = rawData.tradeVolume,
         )
 
         outboxService.saveOutboxRecord(

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/internal/RawTickDataReceivedEventHandler.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/event/internal/RawTickDataReceivedEventHandler.kt
@@ -22,13 +22,11 @@ class RawTickDataReceivedEventHandler(
     fun handle(event: RawTickDataReceivedEvent) {
         val rawData = event.priceData
 
-        val seoulZoneId = ZoneId.of("Asia/Seoul")
-
         val businessDate = LocalDate.parse(rawData.businessDate, dateFormatter)
         val executionTime = LocalTime.parse(rawData.executionTime, timeFormatter)
 
         val localDateTime = LocalDateTime.of(businessDate, executionTime)
-        val zonedDateTime = localDateTime.atZone(seoulZoneId)
+        val zonedDateTime = localDateTime.atZone(ZoneId.systemDefault())
         val timestamp = zonedDateTime.toInstant()
 
         val eventPayload = StockPriceUpdatedEvent.Payload(

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/kis/dto/KisRealtimePriceData.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/kis/dto/KisRealtimePriceData.kt
@@ -57,7 +57,7 @@ data class KisRealtimePriceData(
 
     /** 체결 거래량 */
     @param:JsonProperty("CNTG_VOL")
-    val tradeVolume: BigDecimal,
+    val tradeVolume: Long,
 
     /** 누적 거래량 */
     @param:JsonProperty("ACML_VOL")

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/kis/socket/KisDomesticRealtimeHandler.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/kis/socket/KisDomesticRealtimeHandler.kt
@@ -1,6 +1,6 @@
 package org.mj.mansour.marketdata.kis.socket
 
-import org.mj.mansour.marketdata.event.RawTickDataReceivedEvent
+import org.mj.mansour.marketdata.event.internal.RawTickDataReceivedEvent
 import org.mj.mansour.marketdata.kis.event.KisDomesticSocketConnectedEvent
 import org.mj.mansour.system.core.logging.log
 import org.springframework.context.ApplicationEventPublisher
@@ -49,7 +49,7 @@ class KisDomesticRealtimeHandler(
         if (response != null) {
             manager.updateLastMessageTime()
             response.data.forEach { priceData ->
-                log.info { "  - Symbol: ${priceData.symbol}, Price: ${priceData.currentPrice}, Time: ${priceData.executionTime}, businessDate: ${priceData.businessDate}" }
+                log.info { "  - Symbol: ${priceData.symbol}, Price: ${priceData.currentPrice}, Time: ${priceData.executionTime}, businessDate: ${priceData.businessDate}, tradeVolume: ${priceData.tradeVolume}" }
                 eventPublisher.publishEvent(RawTickDataReceivedEvent(priceData = priceData))
             }
         }

--- a/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/kis/socket/KisDomesticRealtimePriceParser.kt
+++ b/mansour/services/market-data-service/src/main/kotlin/org/mj/mansour/marketdata/kis/socket/KisDomesticRealtimePriceParser.kt
@@ -43,7 +43,7 @@ class KisDomesticRealtimePriceParser {
                     lowestPrice = fields[9].toBigDecimal(),
                     askPrice1 = fields[10].toBigDecimal(),
                     bidPrice1 = fields[11].toBigDecimal(),
-                    tradeVolume = fields[12].toBigDecimal(),
+                    tradeVolume = fields[12].toLong(),
                     accumulatedVolume = fields[13].toBigDecimal(),
                     accumulatedTradeValue = fields[14].toBigDecimal(),
                     sellExecutionCount = fields[15].toBigDecimal(),

--- a/mansour/services/market-data-service/src/main/resources/application.yml
+++ b/mansour/services/market-data-service/src/main/resources/application.yml
@@ -11,11 +11,7 @@ spring:
     hibernate:
       ddl-auto: none
     open-in-view: false
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        default_batch_fetch_size: 1000
+    show-sql: false
 
   kafka:
     consumer:

--- a/mansour/services/market-history-service/market-history-service.gradle.kts
+++ b/mansour/services/market-history-service/market-history-service.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.apache.kafka:kafka-streams")
+    implementation("com.influxdb:influxdb-client-java")
 
     testImplementation("org.springframework.kafka:spring-kafka-test")
 

--- a/mansour/services/market-history-service/market-history-service.gradle.kts
+++ b/mansour/services/market-history-service/market-history-service.gradle.kts
@@ -1,0 +1,16 @@
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+    implementation("org.springframework.kafka:spring-kafka")
+    implementation("org.apache.kafka:kafka-streams")
+
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+
+
+    implementation(project(MansourModules.SHARED_DOMAIN))
+    implementation(project(MansourModules.SYSTEM_CORE))
+    implementation(project(MansourModules.SYSTEM_WEB))
+    implementation(project(MansourModules.SYSTEM_WEBMVC))
+    implementation(project(MansourModules.SYSTEM_JSON))
+    implementation(project(MansourModules.CONTRACTS_MARKET_DATA_SERVICE))
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/MarketHistoryApplication.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/MarketHistoryApplication.kt
@@ -1,0 +1,17 @@
+package org.mj.mansour.markethistory
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@EnableScheduling
+@ConfigurationPropertiesScan
+@EnableDiscoveryClient
+@SpringBootApplication
+class MarketHistoryApplication
+
+fun main(args: Array<String>) {
+    runApplication<MarketHistoryApplication>(*args)
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/api/StockChartController.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/api/StockChartController.kt
@@ -1,0 +1,37 @@
+package org.mj.mansour.markethistory.api
+
+import org.mj.mansour.markethistory.dto.CandleResponse
+import org.mj.mansour.markethistory.dto.CandleSearchCondition
+import org.mj.mansour.markethistory.repository.StockChartRepository
+import org.mj.mansour.system.web.response.ApiResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class StockChartController(
+    private val stockChartRepository: StockChartRepository,
+) {
+
+    @GetMapping("/stock/chart")
+    fun getStockChart(@ModelAttribute condition: CandleSearchCondition): ApiResponse<List<CandleResponse>> {
+        val findCandles = stockChartRepository.findCandles(
+            symbol = condition.symbol,
+            resolution = condition.resolution,
+            from = condition.from,
+            to = condition.to,
+        ).map { candle ->
+            CandleResponse(
+                time = candle.windowStartTime.epochSecond,
+                symbol = candle.symbol,
+                open = candle.open,
+                high = candle.high,
+                low = candle.low,
+                close = candle.close,
+                volume = candle.volume,
+            )
+        }
+
+        return ApiResponse.ok(data = findCandles)
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/api/TestController.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/api/TestController.kt
@@ -1,0 +1,41 @@
+package org.mj.mansour.markethistory.api
+
+import org.mj.mansour.markethistory.domain.StockCandle
+import org.mj.mansour.markethistory.repository.StockPriceRepository
+import org.mj.mansour.system.web.response.ApiResponse
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+import java.math.BigDecimal
+import java.time.Instant
+
+@Profile("local")
+@RestController
+class TestController(
+    private val stockPriceRepository: StockPriceRepository,
+) {
+
+    @PostMapping("/test")
+    fun test() {
+        stockPriceRepository.save(
+            StockCandle(
+                symbol = "005930",
+                open = BigDecimal.valueOf(84400),
+                high = BigDecimal.valueOf(84400),
+                low = BigDecimal.valueOf(84400),
+                close = BigDecimal.valueOf(84400),
+                volume = BigDecimal.valueOf(84400),
+                windowStartTime = Instant.ofEpochSecond(1759135440),
+                windowEndTime = Instant.ofEpochSecond(1759135500)
+            )
+        )
+    }
+
+    @GetMapping("/test2/{symbol}")
+    fun test2(@PathVariable("symbol") symbol: String): ApiResponse<List<StockCandle>> {
+        val findRecentCandles = stockPriceRepository.findRecentCandles(symbol = symbol)
+        return ApiResponse.ok(data = findRecentCandles)
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/api/TestController.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/api/TestController.kt
@@ -1,6 +1,7 @@
 package org.mj.mansour.markethistory.api
 
 import org.mj.mansour.markethistory.domain.StockCandle
+import org.mj.mansour.markethistory.dto.CandleResponse
 import org.mj.mansour.markethistory.repository.StockPriceRepository
 import org.mj.mansour.system.web.response.ApiResponse
 import org.springframework.context.annotation.Profile
@@ -26,7 +27,7 @@ class TestController(
                 high = BigDecimal.valueOf(84400),
                 low = BigDecimal.valueOf(84400),
                 close = BigDecimal.valueOf(84400),
-                volume = BigDecimal.valueOf(84400),
+                volume = 1234L,
                 windowStartTime = Instant.ofEpochSecond(1759135440),
                 windowEndTime = Instant.ofEpochSecond(1759135500)
             )
@@ -34,8 +35,20 @@ class TestController(
     }
 
     @GetMapping("/test2/{symbol}")
-    fun test2(@PathVariable("symbol") symbol: String): ApiResponse<List<StockCandle>> {
+    fun test2(@PathVariable("symbol") symbol: String): ApiResponse<List<CandleResponse>> {
         val findRecentCandles = stockPriceRepository.findRecentCandles(symbol = symbol)
+            .map { candle ->
+                CandleResponse(
+                    time = candle.windowStartTime.epochSecond,
+                    symbol = candle.symbol,
+                    open = candle.open,
+                    high = candle.high,
+                    low = candle.low,
+                    close = candle.close,
+                    volume = candle.volume,
+                )
+            }
+
         return ApiResponse.ok(data = findRecentCandles)
     }
 }

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/KafkaConfig.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/KafkaConfig.kt
@@ -1,0 +1,15 @@
+package org.mj.mansour.markethistory.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.mj.mansour.system.json.DebeziumMessageParser
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class KafkaConfig {
+
+    @Bean
+    fun debeziumMessageParser(objectMapper: ObjectMapper): DebeziumMessageParser {
+        return DebeziumMessageParser(objectMapper)
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/MarketDataStreamConfig.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/MarketDataStreamConfig.kt
@@ -1,0 +1,97 @@
+package org.mj.mansour.markethistory.config
+
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.KeyValue
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.kstream.Consumed
+import org.apache.kafka.streams.kstream.Grouped
+import org.apache.kafka.streams.kstream.Materialized
+import org.apache.kafka.streams.kstream.Produced
+import org.apache.kafka.streams.kstream.Suppressed
+import org.apache.kafka.streams.kstream.TimeWindows
+import org.apache.kafka.streams.processor.api.ProcessorSupplier
+import org.mj.mansour.contract.marketdata.StockPriceUpdatedEvent
+import org.mj.mansour.markethistory.model.OneMinuteCandle
+import org.mj.mansour.markethistory.model.OneMinuteCandleAccumulator
+import org.mj.mansour.system.json.DebeziumMessageParser
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafkaStreams
+import org.springframework.kafka.support.serializer.JsonSerde
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.Instant
+
+@Configuration
+@EnableKafkaStreams
+class MarketDataStreamConfig {
+
+    @Bean
+    fun kStreamTopology(streamsBuilder: StreamsBuilder, debeziumMessageParser: DebeziumMessageParser): StreamsBuilder {
+        // 사용할 Serde(직렬화/역직렬화기)를 명시적으로 정의합니다.
+        val stringSerde = Serdes.String()
+        val tickPayloadSerde = JsonSerde(StockPriceUpdatedEvent.Payload::class.java)
+        val accumulatorSerde = JsonSerde(OneMinuteCandleAccumulator::class.java)
+        val finalCandleSerde = JsonSerde(OneMinuteCandle::class.java)
+
+
+        // 1. 소스(Source): 실시간 체결가 토픽에서 데이터를 읽습니다.
+        streamsBuilder.stream(
+            StockPriceUpdatedEvent.TOPIC,
+            Consumed.with(stringSerde, stringSerde)
+        )
+            .process(ProcessorSupplier { TickDataProcessor(debeziumMessageParser) })
+            // 2. 그룹화(Group): 종목 코드(symbol)를 기준으로 데이터를 묶습니다.
+            .groupBy(
+                { key, value -> value.symbol },
+                Grouped.with(stringSerde, tickPayloadSerde)
+            )
+            // 3. 윈도우(Window): 1분 단위의 겹치지 않는 시간 창으로 그룹을 나눕니다. 5초의 유예 기간을 설정하여, 윈도우가 닫힌 후에도 5초 동안 추가 데이터가 들어올 수 있도록 합니다.
+            .windowedBy(TimeWindows.ofSizeAndGrace(Duration.ofMinutes(1), Duration.ofSeconds(5)))
+            // 4. 집계(Aggregate): 각 윈도우 안의 데이터를 OHLCV 캔들로 집계합니다.
+            .aggregate(
+                // Initializer: 윈도우의 첫 데이터가 들어왔을 때, 초기 캔들 객체를 생성합니다.
+                { OneMinuteCandleAccumulator() },
+                // Aggregator: 윈도우에 새로운 체결 데이터(tick)가 들어올 때마다 캔들 상태를 업데이트합니다.
+                { symbol, tick, candle ->
+                    candle.symbol = symbol
+                    candle.open = if (candle.volume == BigDecimal.ZERO) tick.close else candle.open
+                    candle.high = maxOf(candle.high, tick.close)
+                    candle.low = if (candle.volume == BigDecimal.ZERO) tick.close else minOf(candle.low, tick.close)
+                    candle.close = tick.close
+                    candle.volume += tick.tradeVolume
+                    candle
+                },
+                // 집계 중간 결과를 저장할 상태 저장소(State Store)를 설정합니다.
+                Materialized.with(stringSerde, accumulatorSerde)
+            )
+            // 👇 윈도우가 닫힐 때까지 중간 결과 방출을 억제하고, 최종 결과만 내보냅니다.
+            .suppress(Suppressed.untilWindowCloses(Suppressed.BufferConfig.unbounded()))
+            // 5. 스트림 변환: KTable을 다시 KStream으로 변환하고, Key를 Windowed<String>에서 String으로 복원합니다.
+            .toStream()
+            .map { windowedKey, accumulator ->
+                val finalCandle = OneMinuteCandle(
+                    symbol = accumulator.symbol,
+                    open = accumulator.open,
+                    high = accumulator.high,
+                    low = accumulator.low,
+                    close = accumulator.close,
+                    volume = accumulator.volume,
+                    windowStartTime = Instant.ofEpochMilli(windowedKey.window().start()),
+                    windowEndTime = Instant.ofEpochMilli(windowedKey.window().end())
+                )
+                KeyValue(windowedKey.key(), finalCandle)
+            }
+            .to(
+                CANDLE_TOPIC,
+                Produced.with(stringSerde, finalCandleSerde)
+            )
+
+        return streamsBuilder
+
+    }
+
+    companion object {
+        const val CANDLE_TOPIC = "marketdata.candles.1m"
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/MarketDataStreamConfig.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/MarketDataStreamConfig.kt
@@ -18,7 +18,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafkaStreams
 import org.springframework.kafka.support.serializer.JsonSerde
-import java.math.BigDecimal
 import java.time.Duration
 import java.time.Instant
 
@@ -39,8 +38,7 @@ class MarketDataStreamConfig {
         streamsBuilder.stream(
             StockPriceUpdatedEvent.TOPIC,
             Consumed.with(stringSerde, stringSerde)
-        )
-            .process(ProcessorSupplier { TickDataProcessor(debeziumMessageParser) })
+        ).process(ProcessorSupplier { TickDataProcessor(debeziumMessageParser) })
             // 2. 그룹화(Group): 종목 코드(symbol)를 기준으로 데이터를 묶습니다.
             .groupBy(
                 { key, value -> value.symbol },
@@ -55,9 +53,9 @@ class MarketDataStreamConfig {
                 // Aggregator: 윈도우에 새로운 체결 데이터(tick)가 들어올 때마다 캔들 상태를 업데이트합니다.
                 { symbol, tick, candle ->
                     candle.symbol = symbol
-                    candle.open = if (candle.volume == BigDecimal.ZERO) tick.close else candle.open
+                    candle.open = if (candle.volume == 0L) tick.close else candle.open
                     candle.high = maxOf(candle.high, tick.close)
-                    candle.low = if (candle.volume == BigDecimal.ZERO) tick.close else minOf(candle.low, tick.close)
+                    candle.low = if (candle.volume == 0L) tick.close else minOf(candle.low, tick.close)
                     candle.close = tick.close
                     candle.volume += tick.tradeVolume
                     candle

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/TickDataProcessor.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/TickDataProcessor.kt
@@ -4,6 +4,7 @@ import org.apache.kafka.streams.processor.api.Processor
 import org.apache.kafka.streams.processor.api.ProcessorContext
 import org.apache.kafka.streams.processor.api.Record
 import org.mj.mansour.contract.marketdata.StockPriceUpdatedEvent
+import org.mj.mansour.system.core.logging.log
 import org.mj.mansour.system.json.DebeziumMessageParser
 import org.mj.mansour.system.json.parsePayload
 
@@ -18,22 +19,27 @@ class TickDataProcessor(
     }
 
     override fun process(record: Record<String, String>) {
-        // 1. 이중 포장된 JSON 문자열을 가져옵니다.
-        val doublyEncodedJson = record.value()
+        try {
+            // 1. 이중 포장된 JSON 문자열을 가져옵니다.
+            val doublyEncodedJson = record.value()
 
-        // 2. DebeziumMessageParser를 사용해 Payload 객체로 파싱합니다.
-        val payload = parser.parsePayload<StockPriceUpdatedEvent.Payload>(doublyEncodedJson)
+            // 2. DebeziumMessageParser를 사용해 Payload 객체로 파싱합니다.
+            val payload = parser.parsePayload<StockPriceUpdatedEvent.Payload>(doublyEncodedJson)
 
-        // 3. 파싱된 객체에서 실제 이벤트 시간을 추출합니다.
-        val eventTime = payload.timestamp.toEpochMilli()
+            // 3. 파싱된 객체에서 실제 이벤트 시간을 추출합니다.
+            val eventTime = payload.timestamp.toEpochMilli()
 
-        // 4. 새로운 Record를 생성합니다.
-        //    - Key: 기존과 동일
-        //    - Value: 파싱된 Payload 객체
-        //    - Timestamp: 페이로드에서 추출한 실제 이벤트 시간으로 재지정!
-        val newRecord = Record(record.key(), payload, eventTime)
+            // 4. 새로운 Record를 생성합니다.
+            //    - Key: 기존과 동일
+            //    - Value: 파싱된 Payload 객체
+            //    - Timestamp: 페이로드에서 추출한 실제 이벤트 시간으로 재지정!
+            val newRecord = Record(record.key(), payload, eventTime)
 
-        // 5. 수정된 Record를 다음 프로세서(downstream)로 전달합니다.
-        context.forward(newRecord)
+            // 5. 수정된 Record를 다음 프로세서(downstream)로 전달합니다.
+            context.forward(newRecord)
+        } catch (_: Exception) {
+            // 예외 발생 시 로깅
+            log.error { "Failed to process record: ${record.value()}" }
+        }
     }
 }

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/TickDataProcessor.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/TickDataProcessor.kt
@@ -1,0 +1,39 @@
+package org.mj.mansour.markethistory.config
+
+import org.apache.kafka.streams.processor.api.Processor
+import org.apache.kafka.streams.processor.api.ProcessorContext
+import org.apache.kafka.streams.processor.api.Record
+import org.mj.mansour.contract.marketdata.StockPriceUpdatedEvent
+import org.mj.mansour.system.json.DebeziumMessageParser
+import org.mj.mansour.system.json.parsePayload
+
+class TickDataProcessor(
+    private val parser: DebeziumMessageParser
+) : Processor<String, String, String, StockPriceUpdatedEvent.Payload> {
+
+    private lateinit var context: ProcessorContext<String, StockPriceUpdatedEvent.Payload>
+
+    override fun init(context: ProcessorContext<String, StockPriceUpdatedEvent.Payload>) {
+        this.context = context
+    }
+
+    override fun process(record: Record<String, String>) {
+        // 1. 이중 포장된 JSON 문자열을 가져옵니다.
+        val doublyEncodedJson = record.value()
+
+        // 2. DebeziumMessageParser를 사용해 Payload 객체로 파싱합니다.
+        val payload = parser.parsePayload<StockPriceUpdatedEvent.Payload>(doublyEncodedJson)
+
+        // 3. 파싱된 객체에서 실제 이벤트 시간을 추출합니다.
+        val eventTime = payload.timestamp.toEpochMilli()
+
+        // 4. 새로운 Record를 생성합니다.
+        //    - Key: 기존과 동일
+        //    - Value: 파싱된 Payload 객체
+        //    - Timestamp: 페이로드에서 추출한 실제 이벤트 시간으로 재지정!
+        val newRecord = Record(record.key(), payload, eventTime)
+
+        // 5. 수정된 Record를 다음 프로세서(downstream)로 전달합니다.
+        context.forward(newRecord)
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbConfig.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbConfig.kt
@@ -1,0 +1,20 @@
+package org.mj.mansour.markethistory.config.influxdb
+
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.InfluxDBClientFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class InfluxDbConfig {
+
+    @Bean
+    fun influxDBClient(properties: InfluxDbProperties): InfluxDBClient {
+        return InfluxDBClientFactory.create(
+            properties.url,
+            properties.token.toCharArray(),
+            properties.org,
+            properties.bucket
+        )
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbConfig.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class InfluxDbConfig {
 
-    @Bean
+    @Bean(destroyMethod = "close")
     fun influxDBClient(properties: InfluxDbProperties): InfluxDBClient {
         return InfluxDBClientFactory.create(
             properties.url,

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbProperties.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbProperties.kt
@@ -8,4 +8,8 @@ data class InfluxDbProperties(
     val token: String,
     val org: String,
     val bucket: String
-)
+) {
+    override fun toString(): String {
+        return "InfluxDbProperties(url='$url', token='***', org='$org', bucket='$bucket')"
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbProperties.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/config/influxdb/InfluxDbProperties.kt
@@ -1,0 +1,11 @@
+package org.mj.mansour.markethistory.config.influxdb
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("influxdb")
+data class InfluxDbProperties(
+    val url: String,
+    val token: String,
+    val org: String,
+    val bucket: String
+)

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/domain/StockCandle.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/domain/StockCandle.kt
@@ -6,29 +6,29 @@ import java.math.BigDecimal
 import java.time.Instant
 
 @Measurement(name = "stock_candle")
-class StockCandle(
+data class StockCandle(
     @Column(timestamp = true)
     val windowStartTime: Instant,
 
-    @Column(tag = true)
+    @Column(tag = true, name = "symbol")
     val symbol: String,
 
-    @Column
+    @Column(name = "open")
     val open: BigDecimal,
 
-    @Column
+    @Column(name = "high")
     val high: BigDecimal,
 
-    @Column
+    @Column(name = "low")
     val low: BigDecimal,
 
-    @Column
+    @Column(name = "close")
     val close: BigDecimal,
 
-    @Column
-    val volume: BigDecimal,
+    @Column(name = "volume")
+    val volume: Long,
 
-    @Column
+    @Column(name = "windowEndTime")
     val windowEndTime: Instant,
 ) {
 }

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/domain/StockCandle.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/domain/StockCandle.kt
@@ -1,0 +1,34 @@
+package org.mj.mansour.markethistory.domain
+
+import com.influxdb.annotations.Column
+import com.influxdb.annotations.Measurement
+import java.math.BigDecimal
+import java.time.Instant
+
+@Measurement(name = "stock_candle")
+class StockCandle(
+    @Column(timestamp = true)
+    val windowStartTime: Instant,
+
+    @Column(tag = true)
+    val symbol: String,
+
+    @Column
+    val open: BigDecimal,
+
+    @Column
+    val high: BigDecimal,
+
+    @Column
+    val low: BigDecimal,
+
+    @Column
+    val close: BigDecimal,
+
+    @Column
+    val volume: BigDecimal,
+
+    @Column
+    val windowEndTime: Instant,
+) {
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/dto/CandleResponse.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/dto/CandleResponse.kt
@@ -1,15 +1,13 @@
-package org.mj.mansour.markethistory.model
+package org.mj.mansour.markethistory.dto
 
 import java.math.BigDecimal
-import java.time.Instant
 
-data class OneMinuteCandle(
+data class CandleResponse(
+    val time: Long,
     val symbol: String,
     val open: BigDecimal,
     val high: BigDecimal,
     val low: BigDecimal,
     val close: BigDecimal,
     val volume: Long,
-    val windowStartTime: Instant,
-    val windowEndTime: Instant,
 )

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/dto/CandleSearchCondition.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/dto/CandleSearchCondition.kt
@@ -1,0 +1,11 @@
+package org.mj.mansour.markethistory.dto
+
+import org.mj.mansour.markethistory.enums.Resolution
+import java.time.LocalDateTime
+
+data class CandleSearchCondition(
+    val symbol: String,
+    val from: LocalDateTime,
+    val to: LocalDateTime,
+    val resolution: Resolution,
+)

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/enums/Resolution.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/enums/Resolution.kt
@@ -1,0 +1,10 @@
+package org.mj.mansour.markethistory.enums
+
+enum class Resolution(val value: String) {
+    ONE_MINUTE("1m"),
+    FIVE_MINUTES("5m"),
+    FIFTEEN_MINUTES("15m"),
+    THIRTY_MINUTES("30m"),
+    ONE_HOUR("1h"),
+    ONE_DAY("1d"),
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/event/CandleDbWriter.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/event/CandleDbWriter.kt
@@ -2,20 +2,35 @@ package org.mj.mansour.markethistory.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.mj.mansour.markethistory.config.MarketDataStreamConfig.Companion.CANDLE_TOPIC
+import org.mj.mansour.markethistory.domain.StockCandle
 import org.mj.mansour.markethistory.model.OneMinuteCandle
+import org.mj.mansour.markethistory.repository.StockPriceRepository
+import org.mj.mansour.system.core.logging.log
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Component
 
 @Component
 class CandleDbWriter(
     private val objectMapper: ObjectMapper,
+    private val stockPriceRepository: StockPriceRepository,
 ) {
 
     @KafkaListener(topics = [CANDLE_TOPIC])
     fun handleCandleEvent(message: String) {
-        println("Received candle event: $message")
-
         val candle = objectMapper.readValue(message, OneMinuteCandle::class.java)
-        println("Parsed candle: $candle")
+        log.info { "Parsed candle: $candle" }
+
+        stockPriceRepository.save(
+            StockCandle(
+                symbol = candle.symbol,
+                open = candle.open,
+                high = candle.high,
+                low = candle.low,
+                close = candle.close,
+                volume = candle.volume,
+                windowStartTime = candle.windowStartTime,
+                windowEndTime = candle.windowEndTime
+            )
+        )
     }
 }

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/event/CandleDbWriter.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/event/CandleDbWriter.kt
@@ -1,0 +1,21 @@
+package org.mj.mansour.markethistory.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.mj.mansour.markethistory.config.MarketDataStreamConfig.Companion.CANDLE_TOPIC
+import org.mj.mansour.markethistory.model.OneMinuteCandle
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+class CandleDbWriter(
+    private val objectMapper: ObjectMapper,
+) {
+
+    @KafkaListener(topics = [CANDLE_TOPIC])
+    fun handleCandleEvent(message: String) {
+        println("Received candle event: $message")
+
+        val candle = objectMapper.readValue(message, OneMinuteCandle::class.java)
+        println("Parsed candle: $candle")
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/influx/FluxRecordMapper.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/influx/FluxRecordMapper.kt
@@ -1,0 +1,23 @@
+package org.mj.mansour.markethistory.influx
+
+import com.influxdb.query.FluxRecord
+import java.time.Instant
+
+interface FluxRecordMapper<T> {
+    fun map(record: FluxRecord): T
+}
+
+fun FluxRecord.getInstant(key: String): Instant =
+    getValueByKey(key) as? Instant ?: Instant.EPOCH
+
+fun FluxRecord.getString(key: String): String =
+    getValueByKey(key) as? String ?: ""
+
+fun FluxRecord.getDouble(key: String): Double =
+    getValueByKey(key) as? Double ?: 0.0
+
+fun FluxRecord.getLong(key: String): Long =
+    getValueByKey(key) as? Long ?: 0L
+
+fun FluxRecord.getInstantFromString(key: String): Instant =
+    (getValueByKey(key) as? String)?.let { Instant.parse(it) } ?: Instant.EPOCH

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/influx/InfluxQueryBuilder.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/influx/InfluxQueryBuilder.kt
@@ -1,0 +1,38 @@
+package org.mj.mansour.markethistory.influx
+
+import com.influxdb.client.QueryApi
+
+class InfluxQueryBuilder<T : Any>(
+    private val bucket: String,
+    private val mapper: FluxRecordMapper<T>
+) {
+    private val filters = mutableListOf<String>()
+    private var rangeStart = "-7d"
+    private var limitCount = 100
+
+    fun measurement(name: String) = apply {
+        filters.add("""r._measurement == "$name"""")
+    }
+
+    fun tag(key: String, value: String) = apply {
+        filters.add("""r.$key == "$value"""")
+    }
+
+    fun range(start: String) = apply { rangeStart = start }
+    fun limit(n: Int) = apply { limitCount = n }
+
+    fun execute(queryApi: QueryApi): List<T> {
+        val filterExpr = filters.joinToString(" and ")
+        val query = """
+            from(bucket: "$bucket")
+              |> range(start: $rangeStart)
+              |> filter(fn: (r) => $filterExpr)
+              |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+              |> sort(columns: ["_time"], desc: true)
+              |> limit(n: $limitCount)
+        """.trimIndent()
+
+        return queryApi.query(query)
+            .flatMap { table -> table.records.map { mapper.map(it) } }
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/model/OneMinuteCandle.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/model/OneMinuteCandle.kt
@@ -1,0 +1,15 @@
+package org.mj.mansour.markethistory.model
+
+import java.math.BigDecimal
+import java.time.Instant
+
+data class OneMinuteCandle(
+    val symbol: String,
+    val open: BigDecimal,
+    val high: BigDecimal,
+    val low: BigDecimal,
+    val close: BigDecimal,
+    val volume: BigDecimal,
+    val windowStartTime: Instant,
+    val windowEndTime: Instant,
+)

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/model/OneMinuteCandleAccumulator.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/model/OneMinuteCandleAccumulator.kt
@@ -1,0 +1,12 @@
+package org.mj.mansour.markethistory.model
+
+import java.math.BigDecimal
+
+data class OneMinuteCandleAccumulator(
+    var symbol: String = "",
+    var open: BigDecimal = BigDecimal.ZERO,
+    var high: BigDecimal = BigDecimal.ZERO,
+    var low: BigDecimal = BigDecimal.ZERO,
+    var close: BigDecimal = BigDecimal.ZERO,
+    var volume: BigDecimal = BigDecimal.ZERO
+)

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/model/OneMinuteCandleAccumulator.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/model/OneMinuteCandleAccumulator.kt
@@ -8,5 +8,5 @@ data class OneMinuteCandleAccumulator(
     var high: BigDecimal = BigDecimal.ZERO,
     var low: BigDecimal = BigDecimal.ZERO,
     var close: BigDecimal = BigDecimal.ZERO,
-    var volume: BigDecimal = BigDecimal.ZERO
+    var volume: Long = 0L,
 )

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockCandleMapper.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockCandleMapper.kt
@@ -1,0 +1,27 @@
+package org.mj.mansour.markethistory.repository
+
+import com.influxdb.query.FluxRecord
+import org.mj.mansour.markethistory.domain.StockCandle
+import org.mj.mansour.markethistory.influx.FluxRecordMapper
+import org.mj.mansour.markethistory.influx.getDouble
+import org.mj.mansour.markethistory.influx.getInstantFromString
+import org.mj.mansour.markethistory.influx.getLong
+import org.mj.mansour.markethistory.influx.getString
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class StockCandleMapper : FluxRecordMapper<StockCandle> {
+    override fun map(record: FluxRecord): StockCandle {
+        return StockCandle(
+            windowStartTime = record.time ?: Instant.EPOCH,
+            symbol = record.getString("symbol"),
+            open = record.getDouble("open").toBigDecimal(),
+            high = record.getDouble("high").toBigDecimal(),
+            low = record.getDouble("low").toBigDecimal(),
+            close = record.getDouble("close").toBigDecimal(),
+            volume = record.getLong("volume"),
+            windowEndTime = record.getInstantFromString("windowEndTime")
+        )
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockChartRepository.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockChartRepository.kt
@@ -1,0 +1,59 @@
+package org.mj.mansour.markethistory.repository
+
+import com.influxdb.client.InfluxDBClient
+import org.mj.mansour.markethistory.domain.StockCandle
+import org.mj.mansour.markethistory.enums.Resolution
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Repository
+class StockChartRepository(
+    private val influxDBClient: InfluxDBClient,
+    private val stockCandleMapper: StockCandleMapper
+) {
+
+    fun findCandles(symbol: String, resolution: Resolution, from: LocalDateTime, to: LocalDateTime): List<StockCandle> {
+        val queryApi = influxDBClient.queryApi
+
+        val interval = resolution.value
+
+        val start = from.atZone(ZoneId.systemDefault()).toInstant().epochSecond
+        val stop = to.atZone(ZoneId.systemDefault()).toInstant().epochSecond
+
+        val fluxQuery = """
+        data = from(bucket: "market_history_data")
+          |> range(start: ${start}, stop: ${stop})
+          |> filter(fn: (r) => r._measurement == "stock_candle" and r.symbol == "$symbol")
+
+        // 각 필드별로 집계
+        openData = data
+          |> filter(fn: (r) => r._field == "open")
+          |> aggregateWindow(every: $interval, fn: first, createEmpty: false)
+
+        highData = data
+          |> filter(fn: (r) => r._field == "high")
+          |> aggregateWindow(every: $interval, fn: max, createEmpty: false)
+
+        lowData = data
+          |> filter(fn: (r) => r._field == "low")
+          |> aggregateWindow(every: $interval, fn: min, createEmpty: false)
+
+        closeData = data
+          |> filter(fn: (r) => r._field == "close")
+          |> aggregateWindow(every: $interval, fn: last, createEmpty: false)
+
+        volumeData = data
+          |> filter(fn: (r) => r._field == "volume")
+          |> aggregateWindow(every: $interval, fn: sum, createEmpty: false)
+
+        // 합치기
+        union(tables: [openData, highData, lowData, closeData, volumeData])
+          |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+          |> sort(columns: ["_time"], desc: true)
+    """.trimIndent()
+
+        return queryApi.query(fluxQuery)
+            .flatMap { table -> table.records.map { stockCandleMapper.map(it) } }
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockPriceRepository.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockPriceRepository.kt
@@ -1,0 +1,69 @@
+package org.mj.mansour.markethistory.repository
+
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.domain.WritePrecision
+import com.influxdb.query.FluxTable
+import org.mj.mansour.markethistory.domain.StockCandle
+import org.springframework.stereotype.Repository
+import java.math.BigDecimal
+import java.time.Instant
+
+@Repository
+class StockPriceRepository(
+    private val influxDBClient: InfluxDBClient,
+) {
+    fun save(candle: StockCandle) {
+        val writeApi = influxDBClient.makeWriteApi()
+        writeApi.writeMeasurement(WritePrecision.S, candle)
+    }
+
+    /**
+     * 특정 종목의 최근 100개 1분봉 데이터를 시간순으로 조회합니다.
+     */
+    fun findRecentCandles(symbol: String, limit: Int = 100): List<StockCandle> {
+        // 1. 쿼리를 실행할 QueryApi 객체를 가져옵니다.
+        val queryApi = influxDBClient.queryApi
+
+        // 2. Flux 쿼리를 작성합니다.
+        val fluxQuery = """
+            from(bucket: "market_data")
+              |> range(start: -7d)
+              |> filter(fn: (r) => r._measurement == "stock_candle" and r.symbol == "$symbol")
+              |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+              |> rename(columns: {_time: "windowStartTime"}) // 1. _time 컬럼을 DTO의 필드명과 일치시킵니다.
+              |> keep(columns: [
+                    "windowStartTime", "symbol", "open", "high", "low",
+                    "close", "volume", "windowEndTime"
+                 ]) // 2. DTO에 정의된 필드만 정확히 선택합니다.
+              |> sort(columns: ["windowStartTime"], desc: true) // 3. 정렬 기준을 명확히 합니다.
+              |> limit(n: $limit)
+        """.trimIndent()
+
+
+        val tables: List<FluxTable> = queryApi.query(fluxQuery)
+        val candles = mutableListOf<StockCandle>()
+
+        for (table in tables) {
+            for (record in table.records) {
+                candles.add(
+                    StockCandle(
+                        // record.time은 Instant? 타입입니다.
+                        windowStartTime = record.time ?: Instant.EPOCH,
+                        // record.getValueByKey는 Any? 타입이므로, 안전하게 캐스팅합니다.
+                        symbol = record.getValueByKey("symbol") as? String ?: "",
+                        open = record.getValueByKey("open") as? BigDecimal ?: BigDecimal.ZERO,
+                        high = record.getValueByKey("high") as? BigDecimal ?: BigDecimal.ZERO,
+                        low = record.getValueByKey("low") as? BigDecimal ?: BigDecimal.ZERO,
+                        close = record.getValueByKey("close") as? BigDecimal ?: BigDecimal.ZERO,
+                        volume = record.getValueByKey("volume") as? BigDecimal ?: BigDecimal.ZERO,
+                        // 3. windowEndTime을 String으로 받아 Instant로 직접 파싱합니다.
+                        windowEndTime = (record.getValueByKey("windowEndTime") as? String)
+                            ?.let { Instant.parse(it) } ?: Instant.EPOCH
+                    )
+                )
+            }
+        }
+        return candles
+
+    }
+}

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockPriceRepository.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockPriceRepository.kt
@@ -14,9 +14,14 @@ class StockPriceRepository(
 ) {
 
     fun save(candle: StockCandle) {
-        val writeApi = influxDBClient.writeApiBlocking
-        writeApi.writeMeasurement(WritePrecision.S, candle)
-        log.info { "Saved candle $candle" }
+        try {
+            val writeApi = influxDBClient.writeApiBlocking
+            writeApi.writeMeasurement(WritePrecision.S, candle)
+            log.info { "Saved candle $candle" }
+        } catch (e: Exception) {
+            log.error(e) { "Failed to save candle $candle" }
+            throw e
+        }
     }
 
 

--- a/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockPriceRepository.kt
+++ b/mansour/services/market-history-service/src/main/kotlin/org/mj/mansour/markethistory/repository/StockPriceRepository.kt
@@ -2,68 +2,30 @@ package org.mj.mansour.markethistory.repository
 
 import com.influxdb.client.InfluxDBClient
 import com.influxdb.client.domain.WritePrecision
-import com.influxdb.query.FluxTable
 import org.mj.mansour.markethistory.domain.StockCandle
+import org.mj.mansour.markethistory.influx.InfluxQueryBuilder
+import org.mj.mansour.system.core.logging.log
 import org.springframework.stereotype.Repository
-import java.math.BigDecimal
-import java.time.Instant
 
 @Repository
 class StockPriceRepository(
     private val influxDBClient: InfluxDBClient,
+    private val stockCandleMapper: StockCandleMapper
 ) {
+
     fun save(candle: StockCandle) {
-        val writeApi = influxDBClient.makeWriteApi()
+        val writeApi = influxDBClient.writeApiBlocking
         writeApi.writeMeasurement(WritePrecision.S, candle)
+        log.info { "Saved candle $candle" }
     }
 
-    /**
-     * 특정 종목의 최근 100개 1분봉 데이터를 시간순으로 조회합니다.
-     */
+
     fun findRecentCandles(symbol: String, limit: Int = 100): List<StockCandle> {
-        // 1. 쿼리를 실행할 QueryApi 객체를 가져옵니다.
-        val queryApi = influxDBClient.queryApi
-
-        // 2. Flux 쿼리를 작성합니다.
-        val fluxQuery = """
-            from(bucket: "market_data")
-              |> range(start: -7d)
-              |> filter(fn: (r) => r._measurement == "stock_candle" and r.symbol == "$symbol")
-              |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
-              |> rename(columns: {_time: "windowStartTime"}) // 1. _time 컬럼을 DTO의 필드명과 일치시킵니다.
-              |> keep(columns: [
-                    "windowStartTime", "symbol", "open", "high", "low",
-                    "close", "volume", "windowEndTime"
-                 ]) // 2. DTO에 정의된 필드만 정확히 선택합니다.
-              |> sort(columns: ["windowStartTime"], desc: true) // 3. 정렬 기준을 명확히 합니다.
-              |> limit(n: $limit)
-        """.trimIndent()
-
-
-        val tables: List<FluxTable> = queryApi.query(fluxQuery)
-        val candles = mutableListOf<StockCandle>()
-
-        for (table in tables) {
-            for (record in table.records) {
-                candles.add(
-                    StockCandle(
-                        // record.time은 Instant? 타입입니다.
-                        windowStartTime = record.time ?: Instant.EPOCH,
-                        // record.getValueByKey는 Any? 타입이므로, 안전하게 캐스팅합니다.
-                        symbol = record.getValueByKey("symbol") as? String ?: "",
-                        open = record.getValueByKey("open") as? BigDecimal ?: BigDecimal.ZERO,
-                        high = record.getValueByKey("high") as? BigDecimal ?: BigDecimal.ZERO,
-                        low = record.getValueByKey("low") as? BigDecimal ?: BigDecimal.ZERO,
-                        close = record.getValueByKey("close") as? BigDecimal ?: BigDecimal.ZERO,
-                        volume = record.getValueByKey("volume") as? BigDecimal ?: BigDecimal.ZERO,
-                        // 3. windowEndTime을 String으로 받아 Instant로 직접 파싱합니다.
-                        windowEndTime = (record.getValueByKey("windowEndTime") as? String)
-                            ?.let { Instant.parse(it) } ?: Instant.EPOCH
-                    )
-                )
-            }
-        }
-        return candles
-
+        return InfluxQueryBuilder("market_history_data", stockCandleMapper)
+            .measurement("stock_candle")
+            .tag("symbol", symbol)
+            .range("-7d")
+            .limit(limit)
+            .execute(influxDBClient.queryApi)
     }
 }

--- a/mansour/services/market-history-service/src/main/resources/application-local.yml
+++ b/mansour/services/market-history-service/src/main/resources/application-local.yml
@@ -1,0 +1,4 @@
+spring:
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:9092

--- a/mansour/services/market-history-service/src/main/resources/application-local.yml
+++ b/mansour/services/market-history-service/src/main/resources/application-local.yml
@@ -7,4 +7,4 @@ influxdb:
   url: http://localhost:18086
   token: my-super-secret-auth-token
   org: mansour
-  bucket: market_data
+  bucket: market_history_data

--- a/mansour/services/market-history-service/src/main/resources/application-local.yml
+++ b/mansour/services/market-history-service/src/main/resources/application-local.yml
@@ -2,3 +2,9 @@ spring:
   kafka:
     consumer:
       bootstrap-servers: localhost:9092
+
+influxdb:
+  url: http://localhost:18086
+  token: my-super-secret-auth-token
+  org: mansour
+  bucket: market_data

--- a/mansour/services/market-history-service/src/main/resources/application.yml
+++ b/mansour/services/market-history-service/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+server:
+  port: 8085
+
+spring:
+  application:
+    name: market-history-service
+  profiles:
+    default: local
+
+  kafka:
+    consumer:
+      group-id: market-history-service-group
+    streams:
+      application-id: market-history-aggregator
+      properties:
+        # 처음 실행 시, 토픽의 가장 오래된 데이터부터 처리 시작
+        auto.offset.reset: earliest
+        # 기본 Key/Value (역)직렬화 방식을 지정
+        # JsonSerde가 ObjectMapper를 자동으로 사용해줌
+        default.key.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
+        default.value.serde: org.springframework.kafka.support.serializer.JsonSerde
+
+eureka:
+  client:
+    enabled: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 마켓 히스토리 서비스 추가: 1분 봉 집계 파이프라인, 저장 및 /stock/chart 조회 엔드포인트, 로컬 테스트 엔드포인트 제공
  - Kafka 스트림 처리와 CANDLE 토픽 발행/처리 파이프라인 제공
- 변경 사항
  - 이벤트 페이로드에 개별 거래량(tradeVolume) 필드 추가 및 거래량 타입 단순화, 실시간 로그에 거래량 포함
- 구성
  - docker-compose에 InfluxDB 2.x 서비스 추가 및 초기화 환경 설정, 관련 의존성 및 로컬 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->